### PR TITLE
Fixed compatibility issue w/ Kodi Helix (14.x)

### DIFF
--- a/plugin.audio.subsonic/addon.xml
+++ b/plugin.audio.subsonic/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.audio.subsonic" version="0.3.0" name="Subsonic" provider-name="t0mm0">
     <requires>
-        <import addon="xbmc.python" version="1.0"/>
+        <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.simplejson" version="2.0.10"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">

--- a/plugin.audio.subsonic/resources/lib/Subsonic/Addon.py
+++ b/plugin.audio.subsonic/resources/lib/Subsonic/Addon.py
@@ -27,7 +27,7 @@ def log(msg, err=False):
         xbmc.log(addon.getAddonInfo('name') + ': ' + msg.encode('utf-8'), 
                  xbmc.LOGERROR)    
     else:
-        xbmc.output(addon.getAddonInfo('name') + ': ' + msg.encode('utf-8'), 
+        xbmc.log(addon.getAddonInfo('name') + ': ' + msg.encode('utf-8'), 
                     xbmc.LOGDEBUG)    
 
 def show_error(details):


### PR DESCRIPTION
Using the deprecated version 1.0 of the xbmc python library caused the plugin to fail installation. Fixed by changing the dependency version, and removing the deprecated xbmc.output call.
